### PR TITLE
6x: Enable QtQuick

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,7 +37,6 @@ then
   )
   rm -r build_native
   CMAKE_ARGS="${CMAKE_ARGS} -DQFP_SHIBOKEN_HOST_PATH=${BUILD_PREFIX} -DQT_HOST_PATH=${BUILD_PREFIX} -DQFP_PYTHON_HOST_PATH=${BUILD_PREFIX}/bin/python"
-  CMAKE_ARGS="${CMAKE_ARGS} -DDISABLE_QtQuickWidgets=TRUE -DDISABLE_QtQuickControls2=TRUE -DDISABLE_QtQuick=TRUE -DDISABLE_QtQml=TRUE"
 fi
 
 mkdir build && cd build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     - patches/build_generator.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -175,11 +175,11 @@ test:
     #- PySide6.QtPdfWidgets
     - PySide6.QtPositioning
     - PySide6.QtPrintSupport
-    #- PySide6.QtQml
-    #- PySide6.QtQuick
+    - PySide6.QtQml
+    - PySide6.QtQuick
     #- PySide6.QtQuick3D
-    #- PySide6.QtQuickControls2
-    #- PySide6.QtQuickWidgets
+    - PySide6.QtQuickControls2
+    - PySide6.QtQuickWidgets
     #- PySide6.QtRemoteObjects
     #- PySide6.QtScript
     #- PySide6.QtScriptTools


### PR DESCRIPTION
The arm64 build of qt6-main hit the timeout and was not published so qml was missing.