### PR TITLE
Rebuild without qt-webengine as hard dependency for aarch64

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jan-janssen @jschueller
+* @hmaarrfk @jan-janssen @jschueller

--- a/README.md
+++ b/README.md
@@ -295,9 +295,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@hmaarrfk](https://github.com/hmaarrfk/)
 * [@jan-janssen](https://github.com/jan-janssen/)
 * [@jschueller](https://github.com/jschueller/)
-
-
-<!-- dummy commit to enable rerendering -->
 

--- a/README.md
+++ b/README.md
@@ -298,3 +298,6 @@ Feedstock Maintainers
 * [@jan-janssen](https://github.com/jan-janssen/)
 * [@jschueller](https://github.com/jschueller/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     - patches/python3.11.patch  # [py>=311]
 
 build:
-  number: 4
+  number: 5
   detect_binary_files_with_prefix: true
   entry_points:
     - pyside2-designer = PySide2.scripts.pyside_tool:designer
@@ -40,6 +40,7 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - pyside2  {{ qt_main }}                 # [build_platform != target_platform]
     - qt-main                                # [build_platform != target_platform]
+    - qt-webengine                           # [build_platform != target_platform]
     - cmake
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've rerendered the recipe as instructed in #149.


Here's a checklist to do before merging.
- [ ] Bump the build number if needed.

Fixes #149