### PR TITLE
Unpin libxml2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     - patches/pysidebug-2127.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -39,7 +39,7 @@ requirements:
     - python                             # [build_platform != target_platform]
     #- cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - libxslt                            # [build_platform != target_platform]
-    - libxml2 2.9.*                      # [build_platform != target_platform]
+    - libxml2                            # [build_platform != target_platform]
     - qt6-main                           # [build_platform != target_platform]
     - sysroot_linux-64 2.17              # [linux]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
@@ -89,7 +89,7 @@ requirements:
   host:
     - python
     - libxslt
-    - libxml2 2.9.*
+    - libxml2
     - qt6-main
     - llvmdev
     - clangdev


### PR DESCRIPTION
libxml moved to 2.10

All old repos got patched, so these new builds aren't being patched for compatibility.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
