### PR TITLE
Fix python 3.10 with 6.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,7 @@ requirements:
     - qt6-datavis3d
     - qt6-graphs
     - qt6-wayland  # [linux]
+    # Provides QtMultimediaWidgets and QtSpatialAudio
     - qt6-multimedia
     - llvmdev
     - clangdev >=9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - patches/tools.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
   entry_points:
     - pyside6-rcc = PySide6.scripts.pyside_tool:rcc
@@ -88,6 +88,7 @@ test:
     - qt6-charts           # [py==310]
     - qt6-datavis3d        # [py==310]
     - qt6-graphs           # [py==310]
+    - qt6-multimedia       # [py==310]
 
     - sysroot_linux-64 2.17              # [linux]
     - {{ cdt('mesa-libgl-devel') }}      # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -133,7 +133,7 @@ test:
     # - PySide6.QtScxml
     # - PySide6.QtSensors
     # - PySide6.QtSerialPort
-    - PySide6.QtSpatialAudio
+    - PySide6.QtSpatialAudio       # [py==310]
     - PySide6.QtSql
     #- PySide6.QtStateMachine
     - PySide6.QtSvg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ test:
     - PySide6.QtPrintSupport
     - PySide6.QtQml
     - PySide6.QtQuick
-    #- PySide6.QtQuick3D
+    - PySide6.QtQuick3D
     - PySide6.QtQuickControls2
     - PySide6.QtQuickWidgets
     #- PySide6.QtRemoteObjects

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,7 +90,6 @@ test:
     - qt6-graphs           # [py==310]
     - qt6-multimedia       # [py==310]
 
-    - sysroot_linux-64 2.17              # [linux]
     - {{ cdt('mesa-libgl-devel') }}      # [linux]
     - {{ cdt('mesa-libegl-devel') }}     # [linux]
     - {{ cdt('mesa-dri-drivers') }}      # [linux]
@@ -115,7 +114,7 @@ test:
     - PySide6.QtHelp
     #- PySide6.QtHttpServer
     - PySide6.QtMultimedia         # [py==310]
-    - PySide6.QtMultimediaWidgets
+    - PySide6.QtMultimediaWidgets  # [py==310]
     - PySide6.QtNetwork
     #- PySide6.QtNetworkAuth
     #- PySide6.QtNfc


### PR DESCRIPTION
The impending release of qt-multimedia made certain tests pass when they shouldn't have prior to merging

Lets see what happens now

depends on: https://github.com/conda-forge/qt-main-feedstock/pull/264

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
