### PR TITLE
Add qtcharts for pyside6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,7 +84,7 @@ test:
     # these are optional
     # test them with one version of python
     - qt6-3d               # [py==310]
-    - qt6-charts           # [py==310]
+    - qt6-charts
     - qt6-datavis3d        # [py==310]
     - qt6-graphs           # [py==310]
     - qt6-multimedia       # [py==310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,7 @@ test:
     - PySide6.Qt3DLogic            # [py==310]
     - PySide6.Qt3DRender           # [py==310]
     #- PySide6.QtBluetooth
-    - PySide6.QtCharts             # [py==310]
+    - PySide6.QtCharts
     - PySide6.QtConcurrent
     - PySide6.QtCore
     - PySide6.QtDataVisualization  # [py==310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ build:
   ignore_run_exports:
     # make it optional
     - qt6-3d
-    - qt6-charts
+    #- qt6-charts
     - qt6-datavis3d
     - qt6-graphs
     - qt6-wayland

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - patches/tools.patch
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - pyside6-rcc = PySide6.scripts.pyside_tool:rcc
     - pyside6-uic = PySide6.scripts.pyside_tool:uic


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

We are currently using QtCharts in our applications, but it is not supported in the existing setup. Therefore, we need to include the QtCharts DLLs to ensure that our applications continue to function properly with charting capabilities.