### PR TITLE
Fix memory leak in QtCore.QByteArray() with FORCE_LIMITED_API=OFF

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,11 @@ source:
     # change tools module location
     - patches/tools.patch
 
+    # https://github.com/pyqtgraph/pyqtgraph/issues/3265
+    - patches/0001-Fix-memory-leak.patch
+
 build:
-  number: 0
+  number: 1
   entry_points:
     - pyside6-rcc = PySide6.scripts.pyside_tool:rcc
     - pyside6-uic = PySide6.scripts.pyside_tool:uic

--- a/recipe/patches/0001-Fix-memory-leak.patch
+++ b/recipe/patches/0001-Fix-memory-leak.patch
@@ -1,0 +1,26 @@
+From 4da546552760153e8439da6fd8f1d2c327afe19a Mon Sep 17 00:00:00 2001
+From: Jindrich Makovicka <jindrich.makovicka@qminers.com>
+Date: Fri, 28 Feb 2025 08:21:32 -0500
+Subject: [PATCH] Fix memory leak
+
+Change-Id: Icbbcee9d33fcefaea19d0d4883131ed50fe70e34
+---
+ sources/pyside6/PySide6/glue/qtcore.cpp | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/sources/pyside6/PySide6/glue/qtcore.cpp b/sources/pyside6/PySide6/glue/qtcore.cpp
+index da8442d14..1e8488d81 100644
+--- a/sources/pyside6/PySide6/glue/qtcore.cpp
++++ b/sources/pyside6/PySide6/glue/qtcore.cpp
+@@ -821,8 +821,6 @@ static int SbkQByteArray_getbufferproc(PyObject *obj, Py_buffer *view, int flags
+ #else // Py_LIMITED_API
+     const int result = PyBuffer_FillInfo(view, obj, reinterpret_cast<void *>(cppSelf->data()),
+                                          cppSelf->size(), 0, flags);
+-    if (result == 0)
+-        Py_XINCREF(obj);
+     return result;
+ #endif
+ }
+-- 
+2.48.1
+


### PR DESCRIPTION
With FORCE_LIMITED_API=OFF, PySide increments the refcount twice.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
